### PR TITLE
Run `bundle` after bumping the version in 04f9915

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    semantic (1.0.0)
+    semantic (1.1.0)
 
 GEM
   remote: http://rubygems.org/


### PR DESCRIPTION
Hey @jlindsey, small pull request to fix the version number recorded in `Gemfile.lock` after the version was bumped in 04f9915 _(as mentioned [here](https://github.com/jlindsey/semantic/commit/04f99157ebad4d2494000c9f6fbc5c9a1be50097#commitcomment-3878765))_ ... Thanks!
