### PR TITLE
Suppress Ruby warning: `&' interpreted as argument prefix

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -16,7 +16,7 @@ class Semantic::Version
     end
 
 
-    @major, @minor, @patch = version.split('.').map &:to_i
+    @major, @minor, @patch = version.split('.').map(&:to_i)
   end
 
   def to_a


### PR DESCRIPTION
Hey @jlindsey, another quick one: when running a Ruby syntax check against the `version.rb` file, it was issuing the following warning...

```
version.rb:19: warning: `&' interpreted as argument prefix
```

_(FYI, I used: `ruby -W7 -c core_ext.rb` to run the syntax check)_

Thanks!
