### PR TITLE
Fix Ruby 2.1 warnings

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -78,7 +78,7 @@ module Semantic
 
     def satisfies other_version
       return true if other_version.strip == '*'
-      parts = other_version.split /(\d(.+)?)/, 2
+      parts = other_version.split(/(\d(.+)?)/, 2)
       comparator, other_version_string = parts[0].strip, parts[1].strip
 
       begin
@@ -105,7 +105,7 @@ module Semantic
     end
 
     def tilde_matches? other_version_string
-      this_parts = to_a.collect &:to_s
+      this_parts = to_a.collect(&:to_s)
       other_parts = other_version_string.split('.').reject {|x| x == '*'}
       other_parts == this_parts[0..other_parts.length-1]
     end


### PR DESCRIPTION
Fixes following Ruby warnings:

> gems/ruby-2.1.2/gems/semantic-1.3.0/lib/semantic/version.rb:81: warning: ambiguous first argument; put parentheses or even spaces
> gems/ruby-2.1.2/gems/semantic-1.3.0/lib/semantic/version.rb:108: warning: `&' interpreted as argument prefix
