### PR TITLE
Fixes a bug when assigning an empty string as the build parameter.

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -20,6 +20,10 @@ module Semantic
       @major, @minor, @patch = version.split('.').map(&:to_i)
     end
 
+    def build=(b)
+      @build = (!b.nil? && b.empty?) ? nil : b
+    end
+
     def to_a
       [@major, @minor, @patch, @pre, @build]
     end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -64,6 +64,18 @@ describe Semantic::Version do
       v4.pre.should be_nil
       v4.build.should == 'hello'
     end
+    
+    it "provides round-trip fidelity for an empty build parameter" do
+      v = Semantic::Version.new("1.2.3")
+      v.build = ""
+      expect(Semantic::Version.new(v.to_s).build).to eq(v.build)
+    end
+
+    it "provides round-trip fidelity for a nil build parameter" do
+      v = Semantic::Version.new("1.2.3+build")
+      v.build = nil
+      expect(Semantic::Version.new(v.to_s).build).to eq(v.build)
+    end
   end
 
   context "comparisons" do


### PR DESCRIPTION
It's a shame that the SemVer standard does not allow:
```
1.2.3+
```
to be accepted (and the value of the "build" parameter would be an empty string) but oh well.

With this patch, we transform empty build parameters into a nil.