### PR TITLE
Allow increment! to take both string and symbol as term

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -103,6 +103,7 @@ module Semantic
     end
 
     def increment!(term)
+      term = term.to_sym
       new_version = clone
       new_value = send(term) + 1
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -243,4 +243,22 @@ describe Semantic::Version do
       end
     end
   end
+
+  describe '#increment!' do
+    subject { described_class.new('1.2.3-pre1+build2') }
+
+    context 'changing the minor term' do
+      context 'with a string' do
+        it 'changes the minor term and resets the path, pre and build' do
+          subject.increment!('minor').should == '1.3.0'
+        end
+      end
+
+      context 'with a symbol' do
+        it 'changes the minor term and resets the path, pre and build' do
+          subject.increment!(:minor).should == '1.3.0'
+        end
+      end
+    end
+  end
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -64,7 +64,7 @@ describe Semantic::Version do
       v4.pre.should be_nil
       v4.build.should == 'hello'
     end
-    
+
     it "provides round-trip fidelity for an empty build parameter" do
       v = Semantic::Version.new("1.2.3")
       v.build = ""
@@ -224,7 +224,7 @@ describe Semantic::Version do
     end
   end
 
-  describe '#minor' do
+  describe '#minor!' do
     subject { described_class.new('1.2.3-pre1+build2') }
 
     context 'changing the minor term' do
@@ -234,7 +234,7 @@ describe Semantic::Version do
     end
   end
 
-  describe '#patch' do
+  describe '#patch!' do
     subject { described_class.new('1.2.3-pre1+build2') }
 
     context 'changing the patch term' do


### PR DESCRIPTION
I'm using this Gem, and I got a really weird bug :)
Using increment with string result in a wrong bumped version.

``` ruby
version = Semantic::Version.new('1.2.3')
version.increment!('minor') # 1.3.3
version.increment!(:minor) # 1.3.0
```
