### PR TITLE
Semantic::Version as hash key

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -45,6 +45,14 @@ module Semantic
     alias to_array to_a
     alias to_string to_s
 
+    def hash
+      to_a.hash
+    end
+
+    def eql? other_version
+      self.hash == other_version.hash
+    end
+
     def <=> other_version
       other_version = Version.new(other_version) if other_version.is_a? String
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -64,7 +64,7 @@ describe Semantic::Version do
       v4.pre.should be_nil
       v4.build.should == 'hello'
     end
-    
+
     it "provides round-trip fidelity for an empty build parameter" do
       v = Semantic::Version.new("1.2.3")
       v.build = ""
@@ -212,6 +212,12 @@ describe Semantic::Version do
       v = Semantic::Version.new('0.0.0')
       [:to_hash, :to_array, :to_string].each { |sym| v.should respond_to(sym) }
     end
+  end
+
+  it "as hash key" do
+    hash = {}
+    hash[Semantic::Version.new("1.2.3-pre1+build2")] = "semantic"
+    hash[Semantic::Version.new("1.2.3-pre1+build2")].should eq "semantic"
   end
 
   describe '#major!' do


### PR DESCRIPTION
Below is the behavior of the `Gem::Version` where different instances of the same key would return the same semantic version string:

``` ruby
hash = {}
key1 = Gem::Version.new("1.0.0")
key2 = Gem::Version.new("1.0.0")

hash[key1] = "gem version"
p hash[key2] #=> "gem version"
```

However, next is the present behavior of the `Semantic::Version`:

``` ruby
hash = {}
key1 = Semantic::Version.new("1.0.0")
key2 = Semantic::Version.new("1.0.0")

hash[key1] = "semantic version"
p hash[key2] #=> nil
```

These 2 identical methods behave differently, so with This PR, I've added 2 methods, `Semantic::Version#hash` and `Semantic::Version#eql?`, to make this function same as the original behavior of `Gem::Version`. With this change, the output of above will as:

``` ruby
hash = {}
key1 = Semantic::Version.new("1.0.0")
key2 = Semantic::Version.new("1.0.0")

hash[key1] = "semantic version"
p hash[key2] #=> "semantic version"
```

and returns the actual semantic version as string, identical methods behaving identical as `Gem::Version`.
