### PR TITLE
change satisfies method name

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -90,7 +90,7 @@ module Semantic
       return compare_pre(self.pre, other_version.pre)
     end
 
-    def satisfies other_version
+    def satisfies? other_version
       return true if other_version.strip == '*'
       parts = other_version.split(/(\d(.+)?)/, 2)
       comparator, other_version_string = parts[0].strip, parts[1].strip

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -187,29 +187,29 @@ describe Semantic::Version do
     end
 
     it 'determines whether it satisfies >= style specifications' do
-      expect(@v1_6_0.satisfies('>=1.6.0')).to be true
-      expect(@v1_6_0.satisfies('<=1.6.0')).to be true
-      expect(@v1_6_0.satisfies('>=1.5.0')).to be true
-      expect(@v1_6_0.satisfies('<=1.5.0')).not_to be true
+      expect(@v1_6_0.satisfies?('>=1.6.0')).to be true
+      expect(@v1_6_0.satisfies?('<=1.6.0')).to be true
+      expect(@v1_6_0.satisfies?('>=1.5.0')).to be true
+      expect(@v1_6_0.satisfies?('<=1.5.0')).not_to be true
 
       # partial / non-semver numbers after comparator are extremely common in
       # version specifications in the wild
 
-      expect(@v1_6_0.satisfies('>1.5')).to be true
-      expect(@v1_6_0.satisfies('<1')).not_to be true
+      expect(@v1_6_0.satisfies?('>1.5')).to be true
+      expect(@v1_6_0.satisfies?('<1')).not_to be true
     end
 
     it 'determines whether it satisfies * style specifications' do
-      expect(@v1_6_0.satisfies('1.*')).to be true
-      expect(@v1_6_0.satisfies('1.6.*')).to be true
-      expect(@v1_6_0.satisfies('2.*')).not_to be true
-      expect(@v1_6_0.satisfies('1.5.*')).not_to be true
+      expect(@v1_6_0.satisfies?('1.*')).to be true
+      expect(@v1_6_0.satisfies?('1.6.*')).to be true
+      expect(@v1_6_0.satisfies?('2.*')).not_to be true
+      expect(@v1_6_0.satisfies?('1.5.*')).not_to be true
     end
 
     it 'determines whether it satisfies ~ style specifications' do
-      expect(@v1_6_0.satisfies('~1.6')).to be true
-      expect(@v1_5_9_pre_1.satisfies('~1.5')).to be true
-      expect(@v1_6_0.satisfies('~1.5')).not_to be true
+      expect(@v1_6_0.satisfies?('~1.6')).to be true
+      expect(@v1_5_9_pre_1.satisfies?('~1.5')).to be true
+      expect(@v1_6_0.satisfies?('~1.5')).not_to be true
     end
   end
 


### PR DESCRIPTION
As `satisfies` only returns boolean value, this PR modifies method name to `satisfies?` to align with ruby patterns.

@jlindsey 