### PR TITLE
add satisfied_by? functionality for range of versions

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -108,6 +108,11 @@ module Semantic
       end
     end
 
+    def satisfied_by? versions
+      raise ArgumentError.new("Versions #{versions} should be an array of versions") unless versions.is_a? Array
+      versions.all? { |version| satisfies(version) }
+    end
+
     [:major, :minor, :patch].each do |term|
       define_method("#{term}!") { increment!(term) }
     end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -211,6 +211,29 @@ describe Semantic::Version do
       expect(@v1_5_9_pre_1.satisfies('~1.5')).to be true
       expect(@v1_6_0.satisfies('~1.5')).not_to be true
     end
+
+    it 'determines whether version is satisfies by range of bound versions' do
+      v5_2_1 = Semantic::Version.new('5.2.1')
+      v5_3_0 = Semantic::Version.new('5.3.0')
+      v6_0_1 = Semantic::Version.new('6.0.1')
+      range = [
+        ">= 5.2.1",
+        "<= 6.0.0"
+      ]
+
+      expect(v5_2_1.satisfied_by?(range)).to be true
+      expect(v5_3_0.satisfied_by?(range)).to be true
+      expect(v6_0_1.satisfied_by?(range)).to be false
+    end
+
+    it 'raises error if the input is not an array of versions' do
+      v5_2_1 = Semantic::Version.new('5.2.1')
+      range = ">= 5.2.1 <= 6.0.0"
+      expect { v5_2_1.satisfied_by?(range) }.to raise_error(
+        ArgumentError,
+        /should be an array of versions/
+      )
+    end
   end
 
   context 'type coercions' do


### PR DESCRIPTION
This PR adds `satisfied_by?` method which allows to check if a version satisfies range of versions requirements. It would have the similar be behaviour with `Gem::satisfied_by?` .

This needs a rebase once #22 is merged

@jlindsey 