### PR TITLE
Add docs for `increment!` and friends.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ complex_version.build     # => "revision.15623"
 # semantic supports Pessimistic Operator
 version.satisfies? '~> 1.5'    # => true
 version.satisfies? '~> 1.6.0'  # => true
+
+# incrementing version numbers
+version = Semantic::Version.new('0.1.0')
+new_version = version.increment!(:major)    # 1.1.0
+new_version = version.increment!(:minor)    # 0.2.0
+new_version = version.increment!(:patch)    # 0.1.1
+
+new_version = verstion.major!               # 1.1.0
+new_version = verstion.minor!               # 0.2.0
+new_version = verstion.patch!               # 0.1.1
+# (note: increment! & friends return a copy and leave the original unchanged)
 ```
 
 There is also a set of core extensions as an optional require:


### PR DESCRIPTION
It looks like `increment!`, `patch!`, `major!` and `minor!` do not modify the object, but return an incremented copy instead.

This is obviously by design, but is confusing on first use (particularly for people familiar with Rails) as the convention is often that `!` methods modify the object in-place.

Obviously this would cause an issue here as although `version.increment(:patch)` and `version.increment!(:patch)` would be easy to differentiate between, `version.patch` already exists, and does not increment the version like `version.patch!` does. Also, any change would be backwards-incompatible.

So, have updated the docs to clarify things.