### PR TITLE
Change `build` to a reader attribute

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -6,7 +6,8 @@ module Semantic
     SemVerRegexp = /\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][a-zA-Z0-9-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][a-zA-Z0-9-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?\Z/
 
 
-    attr_accessor :major, :minor, :patch, :pre, :build
+    attr_accessor :major, :minor, :patch, :pre
+    attr_reader :build
 
     def initialize version_str
       v = version_str.match(SemVerRegexp)


### PR DESCRIPTION
Since the writer method `build=` is defined lower in the class, we can safely declare `build` a reader method. This cleans up a warning from newer versions of Ruby that complain about the `build=` method being redefined.

/cc @jlindsey