### PR TITLE
Add is_version? method to String

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+sudo: false
 language: ruby
 rvm:
   - 2.1.10
   - 2.2.5
   - 2.3.1
+  - 2.4.3
+  - 2.5.0

--- a/lib/semantic/core_ext.rb
+++ b/lib/semantic/core_ext.rb
@@ -2,4 +2,8 @@ class String
   def to_version
     Semantic::Version.new self
   end
+
+  def is_version?
+    (match Semantic::Version::SemVerRegexp) ? true : false
+  end
 end

--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -43,5 +43,21 @@ describe 'Core Extensions' do
         )
       end
     end
+
+    it 'extends String with a #is_version? method' do
+      expect('').to respond_to(:is_version?)
+    end
+
+    it 'detects valid semantic version strings' do
+      @test_versions.each do |v|
+        expect(v.is_version?).to be true
+      end
+    end
+
+    it 'detects invalid semantic version strings' do
+      @bad_versions.each do |v|
+        expect(v.is_version?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
An `is_version?` method would allow checking if a string is valid or not without resorting to attempting to instantiate `Semantic::Version` and waiting for an exception and then catching it.