### PR TITLE
Remove superfluous ternary

### DIFF
--- a/lib/semantic/core_ext.rb
+++ b/lib/semantic/core_ext.rb
@@ -4,6 +4,6 @@ class String
   end
 
   def is_version?
-    (match Semantic::Version::SemVerRegexp) ? true : false
+    Semantic::Version::SemVerRegexp.match? self
   end
 end

--- a/lib/semantic/core_ext.rb
+++ b/lib/semantic/core_ext.rb
@@ -4,6 +4,6 @@ class String
   end
 
   def is_version?
-    Semantic::Version::SemVerRegexp.match? self
+    !Semantic::Version::SemVerRegexp.match(self).nil?
   end
 end


### PR DESCRIPTION
Hey @jlindsey - a minor improvement to the `String#is_version?` core extension in #33 - the original implementation uses a ternary, which - it turns out - is superfluous and easy to factor out... thanks!

---

NOTE: my original refactor in 64ce122 is the more succinct implementation of the predicate, but depends on `Regexp#match?` which is only supported in Ruby versions 2.4.x and up, hence my more portable implementation in 6e279ac, which is still better than the original ternary IMO.