### PR TITLE
Malformed "other_versions" should not raise

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -93,6 +93,7 @@ module Semantic
 
     def satisfies? other_version
       return true if other_version.strip == '*'
+      return false unless other_version.match?(/\d/)
       parts = other_version.split(/(\d(.+)?)/, 2)
       comparator, other_version_string = parts[0].strip, parts[1].strip
 

--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -93,7 +93,7 @@ module Semantic
 
     def satisfies? other_version
       return true if other_version.strip == '*'
-      return false unless other_version.match?(/\d/)
+      return false unless other_version.match(/\d/)
       parts = other_version.split(/(\d(.+)?)/, 2)
       comparator, other_version_string = parts[0].strip, parts[1].strip
 


### PR DESCRIPTION
```
irb(main):002:0> Semantic::Version.new("1.2.3").satisfies?("foobar")
Traceback (most recent call last):
        3: from /Users/danielcooper/.rvm/rubies/ruby-2.5.1/bin/irb:11:in `<main>'
        2: from (irb):2
        1: from /Users/danielcooper/.rvm/gems/ruby-2.5.1/gems/semantic-1.6.1/lib/semantic/version.rb:97:in `satisfies?'
NoMethodError (undefined method `strip' for nil:NilClass)
```

I'd expect `.satisfies?` to be safe with any input or to return an ArgumentError in this case.