### PR TITLE
Raise `ArgumentError` if `Version` is initialized with a `nil` version string

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -10,9 +10,8 @@ module Semantic
     attr_reader :build
 
     def initialize version_str
-      v = version_str.match(SemVerRegexp)
+      v = parse_version_string!(version_str)
 
-      raise ArgumentError.new("#{version_str} is not a valid SemVer Version (http://semver.org)") if v.nil?
       @major = v[1].to_i
       @minor = v[2].to_i
       @patch = v[3].to_i
@@ -174,6 +173,14 @@ module Semantic
       raise ArgumentError.new("Version #{version_string} not supported by semverified") if parts.size > 3
       (3 - parts.size).times { parts << '0' }
       parts.join('.')
+    end
+
+    def parse_version_string! version_str
+      if !version_str.nil? && version = version_str.match(SemVerRegexp)
+        version
+      else
+        raise ArgumentError.new("#{version_str} is not a valid SemVer Version (http://semver.org)") if version.nil?
+      end
     end
 
   end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -38,6 +38,15 @@ describe Semantic::Version do
       end
     end
 
+    it 'raises an error when passed nil' do
+      @bad_versions.each do |v|
+        expect { Semantic::Version.new nil }.to raise_error(
+          ArgumentError,
+          /not a valid SemVer/
+        )
+      end
+    end
+
     it 'stores parsed versions in member variables' do
       v1 = Semantic::Version.new '1.5.9'
       expect(v1.major).to eq(1)


### PR DESCRIPTION
At the moment, `Semantic::Version.new` raises a `NoMethodError` exception like this if you try to pass in `nil` as the version string:

```
undefined method `match' for nil:NilClass (NoMethodError)

v = version_str.match(SemVerRegexp)
```

This alters the behaviour to raise an `ArgumentError` instead, which is what we do if you pass a malformed string (e.g. `dasd`). This is a breaking change to the library's API - but it feels like a more reasonable and unsurprising behaviour.